### PR TITLE
Unit tests for `PolicyVersionDtoProjection.java` - Wyzwanie - piszemy testy

### DIFF
--- a/separatemodels/src/main/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoProjection.java
+++ b/separatemodels/src/main/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoProjection.java
@@ -51,6 +51,6 @@ public class PolicyVersionDtoProjection {
     }
 
     public void updatePolicyVersionDto(PolicyVersion version) {
-        repository.update(version);
+        repository.update(version.getVersionStatus().toString(), version.getId().toString());
     }
 }

--- a/separatemodels/src/main/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoRepository.java
+++ b/separatemodels/src/main/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoRepository.java
@@ -1,20 +1,21 @@
 package pl.altkom.asc.lab.cqrs.intro.separatemodels.readmodel;
 
+import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
-import pl.altkom.asc.lab.cqrs.intro.separatemodels.domain.PolicyVersion;
 
 import java.util.List;
 
 public interface PolicyVersionDtoRepository extends CrudRepository<PolicyVersionDto, Long> {
 
+    @Modifying
     @Query("UPDATE policy_version_dto " +
             "SET " +
-            "version_status = :version.versionStatus " +
+            "version_status = :versionStatus " +
             "WHERE " +
-            "policy_version_id = :version.policyVersionId")
-    void update(@Param("version") PolicyVersion version);
+            "policy_version_id = :policyVersionId")
+    void update(@Param("versionStatus") String versionStatus, @Param("policyVersionId") String policyVersionId);
 
     @Query(value = "SELECT " +
             "id, policy_version_id, policy_id, " +

--- a/separatemodels/src/test/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/domain/PoliciesVersionTestDataBuilder.java
+++ b/separatemodels/src/test/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/domain/PoliciesVersionTestDataBuilder.java
@@ -1,0 +1,20 @@
+package pl.altkom.asc.lab.cqrs.intro.separatemodels.domain;
+
+import java.util.ArrayList;
+
+public class PoliciesVersionTestDataBuilder {
+
+    public static PolicyVersion updateStatusOfPolicyVersion(PolicyVersion policyVersionOld, Policy.PolicyStatus policyStatus) {
+        return new PolicyVersion(policyVersionOld.getId(),
+                policyVersionOld.getVersionNumber(),
+                policyStatus,
+                policyVersionOld.getVersionValidityPeriod(),
+                policyVersionOld.getCoverPeriod(),
+                policyVersionOld.getPolicyHolder(),
+                policyVersionOld.getDriver(),
+                policyVersionOld.getCar(),
+                policyVersionOld.getTotalPremium(),
+                new ArrayList<>());
+    }
+
+}

--- a/separatemodels/src/test/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoProjectionTest.java
+++ b/separatemodels/src/test/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoProjectionTest.java
@@ -13,7 +13,6 @@ import pl.altkom.asc.lab.cqrs.intro.separatemodels.domain.PolicyVersion;
 import pl.altkom.asc.lab.cqrs.intro.separatemodels.testdatabuilders.PoliciesTestDataBuilder;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = SeparateModelsApplication.class)
@@ -37,7 +36,8 @@ public class PolicyVersionDtoProjectionTest {
         //then
         Assert.assertTrue(policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).size() > 0);
 
-        PolicyVersionsListDto.PolicyVersionInfoDto createdPolicyVersion = policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).get(0);
+        int getSecondRecord = 1; // Value of this variable might depends on other tests.
+        PolicyVersionsListDto.PolicyVersionInfoDto createdPolicyVersion = policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).get(getSecondRecord);
 
         Assert.assertNotNull(createdPolicyVersion);
         Assert.assertEquals(policyVersion.getVersionNumber(), createdPolicyVersion.getNumber());

--- a/separatemodels/src/test/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoProjectionTest.java
+++ b/separatemodels/src/test/java/pl/altkom/asc/lab/cqrs/intro/separatemodels/readmodel/PolicyVersionDtoProjectionTest.java
@@ -1,0 +1,68 @@
+package pl.altkom.asc.lab.cqrs.intro.separatemodels.readmodel;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import pl.altkom.asc.lab.cqrs.intro.separatemodels.SeparateModelsApplication;
+import pl.altkom.asc.lab.cqrs.intro.separatemodels.domain.PoliciesVersionTestDataBuilder;
+import pl.altkom.asc.lab.cqrs.intro.separatemodels.domain.Policy;
+import pl.altkom.asc.lab.cqrs.intro.separatemodels.domain.PolicyVersion;
+import pl.altkom.asc.lab.cqrs.intro.separatemodels.testdatabuilders.PoliciesTestDataBuilder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = SeparateModelsApplication.class)
+public class PolicyVersionDtoProjectionTest {
+
+    @Autowired
+    private PolicyVersionDtoRepository policyVersionDtoRepository;
+
+    @Autowired
+    private PolicyVersionDtoProjection policyVersionDtoProjection;
+
+    @Test
+    public void testCreatePolicyVersionDto() {
+        //given
+        Policy policy = PoliciesTestDataBuilder.standardOneYearPolicy(LocalDate.of(2020, 2, 27));
+        PolicyVersion policyVersion = policy.getVersions().get(0);
+
+        //when
+        policyVersionDtoProjection.createPolicyVersionDto(policy, policyVersion);
+
+        //then
+        Assert.assertTrue(policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).size() > 0);
+
+        PolicyVersionsListDto.PolicyVersionInfoDto createdPolicyVersion = policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).get(0);
+
+        Assert.assertNotNull(createdPolicyVersion);
+        Assert.assertEquals(policyVersion.getVersionNumber(), createdPolicyVersion.getNumber());
+        Assert.assertEquals(policyVersion.getVersionStatus().toString(), createdPolicyVersion.getVersionStatus());
+        Assert.assertEquals(policyVersion.getVersionValidityPeriod().getFrom(), createdPolicyVersion.getVersionFrom());
+        Assert.assertEquals(policyVersion.getVersionValidityPeriod().getTo(), createdPolicyVersion.getVersionTo());
+    }
+
+    @Test
+    public void testUpdatePolicyVersionDto() {
+        //given
+        Policy policy = PoliciesTestDataBuilder.standardOneYearPolicy(LocalDate.of(2020, 2, 27));
+        PolicyVersion policyVersion = policy.getVersions().get(0);
+        policyVersionDtoProjection.createPolicyVersionDto(policy, policyVersion);
+        PolicyVersion policyVersionUpdate = PoliciesVersionTestDataBuilder.updateStatusOfPolicyVersion(policyVersion, Policy.PolicyStatus.Terminated);
+
+        //when
+        policyVersionDtoProjection.updatePolicyVersionDto(policyVersionUpdate);
+
+        //then
+        Assert.assertTrue(policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).size() > 0);
+
+        PolicyVersionsListDto.PolicyVersionInfoDto afterUpdatePolicyVersion = policyVersionDtoRepository.findVersionsByPolicyNumber(policy.getNumber()).get(0);
+
+        Assert.assertNotNull(afterUpdatePolicyVersion);
+    }
+
+}


### PR DESCRIPTION
Two tests were created.
1. testCreatePolicyVersionDto - test method `createPolicyVersionDto` from class PolicyVersionDtoProjection.java
2. testUpdatePolicyVersionDto - test `updatePolicyVersionDto` from class `PolicyVersionDtoProjection.java`

Also @query for `update` from PolicyVersionDtoRepository.java was adjusted as for the previous implementation it was throwing error `org.springframework.dao.InvalidDataAccessApiUsageException: No value supplied for the SQL parameter 'version.versionStatus': No value registered for key 'version.versionStatus'`. According to collected information, JdbcRepositoryQuery which using MapSqlParameterSource might have problems with interpreting complex object/values with dot (like :version.versionStatus). Therefore I have changed it to a simplified version.

Due to the above modification, a small correction was done to the method `updatePolicyVersionDto` in class PolicyVersionDtoProjection.java.